### PR TITLE
editing pass from the docs team

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -7,249 +7,369 @@ content_type: tutorial
 weight: 30
 ---
 
-<!-- overview -->
+Kubernetes lets you manage dynamic environments that you can change without altering your
+application's code or image by using Redis. To do this, you must configure Redis using your {{<
+glossary_tooltip text="ConfigMap" term_id="configmap">}}. For example, this enables you to
+centralize the configuration for multiple environments or manage dynamic updates to Redis
+configurations.
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This tutorial teaches you how to configure Redis by creating and applying a ConfigMap that holds
+Redis configuration values. You'll create a Redis {{< glossary_tooltip text="Pod" term_id="pod"
+>}}, verify its configuration, update the ConfigMap with new settings, and restart the Pod to apply
+the changes.
+
+This page provides a real world example of how to configure Redis using a ConfigMap and builds upon
+the [Configure a Pod to Use a
+ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
 
-## {{% heading "objectives" %}}
+## What you'll learn
 
+By following this guide, you'll learn to do the following:
 
-* Create a ConfigMap with Redis configuration values
-* Create a Redis Pod that mounts and uses the created ConfigMap
+* Create a ConfigMap with Redis configuration values.
+* Create a Redis Pod that mounts and uses the created ConfigMap.
 * Verify that the configuration was correctly applied.
 
 
 
-## {{% heading "prerequisites" %}}
+## Requirements
 
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+You need to have the following:
 
-* The example shown on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* A Kubernetes cluster.
+* The `kubectl` (version 1.14+) command-line tool configured to communicate with your cluster.
+* You followed [Configure a Pod to Use a
+  ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) to completion.
+
+{{< note title="Don't have a Kubernetes cluster yet?" >}}
+We recommend that you run this tutorial on a cluster with at least two nodes that are not
+acting as control plane hosts. If you do not already have a cluster, you can create one by using
+[minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or you can use one of these
+Kubernetes playgrounds:
+
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
+* [Play with Kubernetes](https://labs.play-with-k8s.com/)
+{{< /note >}}
 
 
+## Step 1: Create a ConfigMap
 
-<!-- lessoncontent -->
+The following steps show you how to set up an empty ConfigMap to hold Redis configuration values.
+
+1. Create a new ConfigMap, using the filename `example-redis-config.yaml`.
+1. Add the following code to the file:
+
+   {{< highlight shell "hl_lines=6" >}}
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: example-redis-config
+   data:
+     redis-config: ""
+   {{< /highlight >}}
+
+   Notice how the `redis-config` block is empty. You'll do more with this later in the tutorial.
 
 
-## Real World Example: Configuring Redis using a ConfigMap
+## Step 2: Deploy the Redis Pod
 
-Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
+To prepare and deploy the necessary resources for Redis to run in your Kubernetes cluster, you must
+first deploy the ConfigMap to ensure the Redis Pod has access to its configuration at runtime. Then,
+you can apply a Pod manifest to deploy the Redis Pod. You'll use the
+[`redis-pod.yaml`](https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml)
+Pod manifest file for this tutorial.
 
-First create a ConfigMap with an empty configuration block:
+1. Use the `kubectl` CLI command to apply the ConfigMap you just created
+   (`example-redis-config.yaml`) to your Kubernetes cluster:
 
-```shell
-cat <<EOF >./example-redis-config.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: example-redis-config
-data:
-  redis-config: ""
-EOF
-```
+   ```shell
+   kubectl apply -f example-redis-config.yaml
+   ```
+1. Use `kubectl` to apply the Pod manifest (`redis-pod.yaml`):
 
-Apply the ConfigMap created above, along with a Redis pod manifest:
+   ```shell
+   kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+   ```
+1. After the Redis Pod has deployed, verify the objects were created:
 
-```shell
-kubectl apply -f example-redis-config.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
-```
+   ```shell
+   kubectl get pod/redis configmap/example-redis-config 
+   ```
+
+   `kubectl` will output similar to the following:
+   
+   ```
+   NAME        READY   STATUS    RESTARTS   AGE
+   pod/redis   1/1     Running   0          8s
+   
+   NAME                             DATA   AGE
+   configmap/example-redis-config   1      14s
+   ```
+
+   If you see `Running` in the `STATUS` column and the Pod is using the
+   `configmap/example-redis-config` ConfigMap, you successfully created and deployed the Redis Pod!
+
+
+## Step 3: Inspect the initial configuration
 
 Examine the contents of the Redis pod manifest and note the following:
 
-* A volume named `config` is created by `spec.volumes[1]`
-* The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
-  `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
-* The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
+* A volume named `config` is defined in `spec.volumes` and populated with data from the
+  `example-redis-config` ConfigMap.
+  * Specifically, the `redis-config` key in the ConfigMap is exposed as a file named `redis.conf`
+    within this volume.
+* The config volume is mounted at `/redis-master` inside the container (via
+  `spec.containers[0].volumeMounts`).
+* This setup allows the file `/redis-master/redis.conf` inside the container to reflect the value of
+  `data.redis-config` in the ConfigMap, enabling Redis to use this configuration.
 
-This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
-ConfigMap above as `/redis-master/redis.conf` inside the Pod.
+{{< highlight yaml "hl_lines=23 28 32 33" >}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+spec:
+  containers:
+  - name: redis
+    image: redis:5.0.4
+    command:
+      - redis-server
+      - "/redis-master/redis.conf"
+    env:
+    - name: MASTER
+      value: "true"
+    ports:
+    - containerPort: 6379
+    resources:
+      limits:
+        cpu: "0.1"
+    volumeMounts:
+    - mountPath: /redis-master-data
+      name: data
+    - mountPath: /redis-master
+      name: config
+  volumes:
+    - name: data
+      emptyDir: {}
+    - name: config
+      configMap:
+        name: example-redis-config
+        items:
+        - key: redis-config
+          path: redis.conf
+{{< /highlight >}}
 
-{{% code_sample file="pods/config/redis-pod.yaml" %}}
+Recall that you left `redis-config` key in the `example-redis-config` ConfigMap empty. Follow these
+steps to verify what this empty configuration looks like:
 
-Examine the created objects:
+1. Check the details of the `exmaple-redis-config` ConfigMap:
 
-```shell
-kubectl get pod/redis configmap/example-redis-config 
-```
+   ```shell
+   kubectl describe configmap/example-redis-config
+   ```
 
-You should see the following output:
+   You should see an empty `redis-config` key:
+   
+   {{< highlight yaml "hl_lines=8" >}}
+   Name:         example-redis-config
+   Namespace:    default
+   Labels:       <none>
+   Annotations:  <none>
+   
+   Data
+   ====
+   redis-config:
+   {{< /highlight >}}
 
-```
-NAME        READY   STATUS    RESTARTS   AGE
-pod/redis   1/1     Running   0          8s
+   This confirms that the `redis-config` is indeed empty.
 
-NAME                             DATA   AGE
-configmap/example-redis-config   1      14s
-```
+1. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
 
-Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
+   ```shell
+   kubectl exec -it redis -- redis-cli
+   ```
 
-```shell
-kubectl describe configmap/example-redis-config
-```
+1. Check `maxmemory`:
 
-You should see an empty `redis-config` key:
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory
+   ```
 
-```shell
-Name:         example-redis-config
-Namespace:    default
-Labels:       <none>
-Annotations:  <none>
+   It should show the default value of 0:
 
-Data
-====
-redis-config:
-```
+   ```shell
+   1) "maxmemory"
+   2) "0"
+   ```
 
-Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
+1. Similarly, check `maxmemory-policy`:
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory-policy
+   ```
 
-Check `maxmemory`:
+   Which should also yield its default value of `noeviction`:
+   
+   ```shell
+   1) "maxmemory-policy"
+   2) "noeviction"
+   ```
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
 
-It should show the default value of 0:
+## Step 4: Update the ConfigMap
 
-```shell
-1) "maxmemory"
-2) "0"
-```
-
-Similarly, check `maxmemory-policy`:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
-
-Which should also yield its default value of `noeviction`:
-
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
-
-Now let's add some configuration values to the `example-redis-config` ConfigMap:
+To illustrate how updating a ConfigMap doesn't alter your application's code or image, update the
+`example-redis-config` ConfigMap to the following:
 
 {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-Apply the updated ConfigMap:
+What these new configuration values mean:
 
-```shell
-kubectl apply -f example-redis-config.yaml
-```
+* `maxmemory 2mb`: Limits Redis memory usage to 2 MB. This is useful in situations where memory is
+  limited like in shared Kubernetes clusters or low-memory environments.
+* `maxmemory-policy allkeys-lru`: Configures Redis to evict the least recently used keys when memory
+  is full. This ensures that frequently accessed keys remain in memory.
 
-Confirm that the ConfigMap was updated:
 
-```shell
-kubectl describe configmap/example-redis-config
-```
+## Step 5: Apply the updated configuration
 
-You should see the configuration values we just added:
+Restart the Redis Pod to apply changes and verify the new settings:
 
-```shell
-Name:         example-redis-config
-Namespace:    default
-Labels:       <none>
-Annotations:  <none>
+1. Apply the updated ConfigMap:
 
-Data
-====
-redis-config:
-----
-maxmemory 2mb
-maxmemory-policy allkeys-lru
-```
+   ```shell
+   kubectl apply -f example-redis-config.yaml
+   ```
 
-Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+1. Confirm that the ConfigMap was updated:
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+   ```shell
+   kubectl describe configmap/example-redis-config
+   ```
 
-Check `maxmemory`:
+   You should see the configuration values you just added:
+   
+   {{< highlight yaml "hl_lines=10 11" >}}
+   Name:         example-redis-config
+   Namespace:    default
+   Labels:       <none>
+   Annotations:  <none>
+   
+   Data
+   ====
+   redis-config:
+   ----
+   maxmemory 2mb
+   maxmemory-policy allkeys-lru
+   {{< /highlight >}}
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
 
-It remains at the default value of 0:
+1. Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was
+   applied:
 
-```shell
-1) "maxmemory"
-2) "0"
-```
+   ```shell
+   kubectl exec -it redis -- redis-cli
+   ```
 
-Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
+1. Check `maxmemory`:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory
+   ```
+   
+   It remains at the default value of `0`:
+   
+   ```shell
+   1) "maxmemory"
+   2) "0"
+   ```
 
-Returns:
+1. Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
 
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory-policy
+   ```
+   
+   Returns:
+   
+   ```shell
+   1) "maxmemory-policy"
+   2) "noeviction"
+   ```
 
-The configuration values have not changed because the Pod needs to be restarted to grab updated
-values from associated ConfigMaps. Let's delete and recreate the Pod:
+1. The configuration values have not changed because the Pod needs to be restarted to grab updated
+   values from associated ConfigMaps. Let's delete and recreate the Pod:
 
-```shell
-kubectl delete pod redis
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
-```
+   ```shell
+   kubectl delete pod redis
+   kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+   ```
 
-Now re-check the configuration values one last time:
+1. Now re-check the configuration values one last time:
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+   ```shell
+   kubectl exec -it redis -- redis-cli
+   ```
 
-Check `maxmemory`:
+1. Check `maxmemory`:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory
+   ```
 
-It should now return the updated value of 2097152:
+   It should now return the updated value of `2097152`:
 
-```shell
-1) "maxmemory"
-2) "2097152"
-```
+   ```shell
+   1) "maxmemory"
+   2) "2097152"
+   ```
 
-Similarly, `maxmemory-policy` has also been updated:
+1. Similarly, `maxmemory-policy` has also been updated:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
+   ```shell
+   127.0.0.1:6379> CONFIG GET maxmemory-policy
+   ```
+   
+   It now reflects the desired value of `allkeys-lru`:
+   
+   ```shell
+   1) "maxmemory-policy"
+   2) "allkeys-lru"
+   ```
 
-It now reflects the desired value of `allkeys-lru`:
 
-```shell
-1) "maxmemory-policy"
-2) "allkeys-lru"
-```
+## Step 6: Clean up resources
 
-Clean up your work by deleting the created resources:
+After completing the tutorial, it's important to remove the created resources to free up cluster
+resources and maintain a clean working environment. This step helps prevent unnecessary resource
+usage and ensures that your Kubernetes environment remains manageable.
 
-```shell
-kubectl delete pod/redis configmap/example-redis-config
-```
+1. Clean up your work by deleting the Redis Pod and ConfigMap:
+
+   ```shell
+   kubectl delete pod/redis configmap/example-redis-config
+   ```
+1. Verify that the resources deleted successfully, run:
+
+   ```shell
+   kubectl get pod/redis configmap/example-redis-config
+   ```
+
+   You should see no output, indicating that the objects no longer exist.
+
+{{< note title="Why the clean up?" >}}
+Leaving unused resources running in a cluster can:
+
+* Waste memory, CPU, or other resources, even if the objects are idle.
+* Cause confusion or issues in shared or production environments if other users try to interact with
+  leftover resources. {{< /note >}}
+
 
 ## {{% heading "whatsnext" %}}
 
-
 * Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-* Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).
+* Follow an example of [Updating configuration via a
+  ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).


### PR DESCRIPTION
### Description

Thanks for your contribution! Please see the following feedback and suggestions that I've submitted in this PR to align this doc with Shopify's dev doc quality standards (see [Content Help documentation](https://polaris.shopify.com/content/help-documentation)): 

General feedback:

### Content organization

1. The introduction would be more helpful to readers if it contained additional context such as:
	1. When/why someone would want to configure Redis using a ConfigMap.
	2. A concrete example (this is an opportunity to explain the "real world" example on this page).
	3. A summary of what readers should expect while following this tutorial.
2. Section headings
	 1. Change the "Objectives" section heading to "What you'll learn" and add a short intro to the list.
	 2. Change the "Before you begin" section heading to "Requirements" and make the content more concise and concrete by using a list and links to important topics for each list item.
	 3. Break up the "Real World Example: Configuring Redis using a ConfigMap" section into a few smaller sections instead of one large section. This will help reduce overwhelming newer users and make the tutorial more readable, especially if they don't complete the tutorial in one go. I suggest creating the following sections to accomplish this:
		 1. Step 1: Create a ConfigMap
		 2. Step 2: Deploy the Redis Pod
		 3. Step 3: Inspect the initial configuration
		 4. Step 4: Update the ConfigMap
		 5. Step 5: Apply the updated configuration
		 6. Step 6: Inspect the new configuration
		 7. Step 7: Clean up resources

### Content style
1. Add numbered lists throughout the doc. Doing so will clearly mark each step in the process, improve the guided experience of the tutorial, and be consistent with Shopify's other tutorials.
2. When addressing the reader, it's best do the following to enhance clarity and avoid the awkwardness of them thinking someone is there with them during the tutorial (you are not with the reader):
	* Talk *to* the reader and not *about* them using second person terms like you, you'll.
	* Exclude yourself by not using terms like use I, I'll, me, we, we'll, us, let's, etc.
	* When referring to Shopify as an entity, it's OK to use "we". For example, use either "Shopify recommends that you ..." or "We recommend that you ...".
3. Several sentences and list items are missing periods at the end of them.
4. If a term or concepts has a glossary entry, use the glossary template when introducing new terms or concepts for the first time. 

### Accessibility and usability
1. Where applicable, replace "above" and "below" with "preceding" and "following" respectively. Using terms like above and below makes it difficult for those using assistive technologies like screen readers to understand precisely what is being referred to. If the term isn't referring to something that immediately precedes or follows the content being read, it's more appropriate to link directly to what you're referring to instead. This coincides with breaking the main section into several sections for better linkability as well!
2. Some links can use more context around them and different link text to make them more accessible. This is key to helping readers understand where they'd go when clicking the link and also why they may want/need to do so.
3. For tutorials, it's best to use less complex methods of file creation like using `cat` and a here document (`<<EOF`) to redirect the output to a file. Instead, just instruct readers to create the file and to add the code snippet's content to it. Removing this complexity will help more novice readers focus on what they're learning in the tutorial and not get distracted by unnecessary complexity.

### Source code formatting
1. I suggest using consistent heading formats throughout the doc with regular Markdown headings to reduce complexity. Using a combination of custom templates and semantic Markdown for headings may be confusing for contributors, especially if there's no difference in the rendered output.
2. I highly suggest using the `highlight` template for code snippets instead of the semantic Markdown when you need to refer to specific lines in them. This will better draw attention to lines that you call out in the context surrounding the code snippets.
3. Using the `{{% code_sample file="pods/config/redis-pod.yaml" %}}` template works, but it lacks the ability to highlight specific lines of code like a `highlight` template does. Being able to highlight lines in longer files is especially useful to get readers looking directly at what's important instead of having to search for it.



